### PR TITLE
Added cloudbuild.yaml for building docker files in the cloud

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -16,3 +16,4 @@ jobs:
         run: |
           docker build -t train:latest . -f dockerfiles/train.dockerfile
           docker build -t evaluate:latest . -f dockerfiles/evaluate.dockerfile
+          docker build -t infer:latest . -f dockerfiles/infer.dockerfile

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,63 @@
+steps:
+# Build training image
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'Build training image'
+  args: [
+    'build',
+    '.',
+    '-t',
+    'europe-west1-docker.pkg.dev/$PROJECT_ID/group-30-container-registry/train-ehr',
+    '-f',
+    'dockerfiles/train.dockerfile'
+  ]
+
+# Push training image
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'Push training image'
+  args: [
+    'push',
+    'europe-west1-docker.pkg.dev/$PROJECT_ID/group-30-container-registry/train-ehr'
+  ]
+
+# Build evaluation image
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'Build evaluation image'
+  args: [
+    'build',
+    '.',
+    '-t',
+    'europe-west1-docker.pkg.dev/$PROJECT_ID/group-30-container-registry/evaluate-ehr',
+    '-f',
+    'dockerfiles/evaluate.dockerfile'
+  ]
+
+# Push evaluation image
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'Push evaluation image'
+  args: [
+    'push',
+    'europe-west1-docker.pkg.dev/$PROJECT_ID/group-30-container-registry/evaluate-ehr'
+  ]
+
+# Build inference image
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'Build inference image'
+  args: [
+    'build',
+    '.',
+    '-t',
+    'europe-west1-docker.pkg.dev/$PROJECT_ID/group-30-container-registry/infer-ehr',
+    '-f',
+    'dockerfiles/infer.dockerfile'
+  ]
+
+# Push inference image
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'Push inference image'
+  args: [
+    'push',
+    'europe-west1-docker.pkg.dev/$PROJECT_ID/group-30-container-registry/infer-ehr'
+  ]
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/dockerfiles/infer.dockerfile
+++ b/dockerfiles/infer.dockerfile
@@ -1,0 +1,31 @@
+# Base image
+FROM python:3.12-slim AS base
+
+# Install system dependencies
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+    build-essential \
+    gcc \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy only requirements first to leverage Docker cache
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt --no-cache-dir
+
+# Copy project files
+COPY pyproject.toml ./
+COPY src/ src/
+COPY configs/ configs/
+COPY data/ data/
+COPY models/ models/
+
+# Install the package
+RUN pip install . --no-deps --no-cache-dir
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Command to run inference
+ENTRYPOINT ["python", "-u", "src/ehr_classification/inference.py"]

--- a/tasks.py
+++ b/tasks.py
@@ -71,6 +71,11 @@ def docker_build(ctx: Context, progress: str = "plain") -> None:
         echo=True,
         pty=not WINDOWS,
     )
+    ctx.run(
+        f"docker build -t infer_ehr:latest . -f dockerfiles/inference.dockerfile --progress={progress}",
+        echo=True,
+        pty=not WINDOWS,
+    )
 
 
 @task(docker_build)
@@ -83,3 +88,9 @@ def docker_train(ctx: Context) -> None:
 def docker_evaluate(ctx: Context) -> None:
     """Run evaluation in Docker container."""
     ctx.run("docker run --rm evaluate_ehr:latest", echo=True, pty=not WINDOWS)
+
+
+@task(docker_build)
+def docker_infer(ctx: Context) -> None:
+    """Run inference in Docker container."""
+    ctx.run("docker run --rm infer_ehr:latest", echo=True, pty=not WINDOWS)


### PR DESCRIPTION
This pull request includes changes to the build and deployment process for Docker images, as well as updates to the Dockerfile and task definitions for inference. The most important changes include adding steps to the `cloudbuild.yaml` file for building and pushing Docker images, creating a new Dockerfile for inference, and updating the `tasks.py` file to include commands for building and running the inference Docker container.

### Build and deployment process:

* [`cloudbuild.yaml`](diffhunk://#diff-0b4a5fc26445836e6672c426692297004cfaba21997343b63e6f58b946bd2a5cR1-R63): Added steps to build and push Docker images for training, evaluation, and inference.

### Dockerfile for inference:

* [`dockerfiles/infer.dockerfile`](diffhunk://#diff-1366159538f3cc7c9178691ca37e8ce868d7dca54fe2a80bb2cd251b712e370dR1-R31): Created a new Dockerfile for the inference process, including installing dependencies, copying project files, and setting environment variables.

### Task definitions:

* [`tasks.py`](diffhunk://#diff-2e746c9eacad6e2c2fdefdc6a665b5ce4607ea384ebf97a729044b79acc778d6R74-R78): Updated the `docker_build` function to include a command for building the inference Docker image.
* [`tasks.py`](diffhunk://#diff-2e746c9eacad6e2c2fdefdc6a665b5ce4607ea384ebf97a729044b79acc778d6R91-R96): Added a new `docker_infer` function to run inference in a Docker container.